### PR TITLE
Add timeouts

### DIFF
--- a/ao3downloader/repo.py
+++ b/ao3downloader/repo.py
@@ -56,7 +56,7 @@ class Repository:
     def my_get(self, url: str) -> requests.Response:
         """Get response from a url."""
 
-        response = self.session.get(url, headers=self.headers)
+        response = self.session.get(url, headers=self.headers, timeout=(30, 30))
 
         if response.status_code == codes['too_many_requests']:
             try:


### PR DESCRIPTION
There's a case where Cloudflare holds a HTTP connection open indefinitely while the AO3 server itself fails to actually send a response.

This adds timeouts so that when that happens, we can at least move on to the next work. 

Example URL with this behavior: 
https://download.archiveofourown.org/downloads/25930015/Welcome_to_the_Worlds.azw3?updated_at=1688946022