### PR TITLE
Fix Issue where work URLs were sometimes malformed

### DIFF
--- a/ao3downloader/parse_soup.py
+++ b/ao3downloader/parse_soup.py
@@ -107,7 +107,7 @@ def get_full_work_url(url: str) -> str:
     """Get full ao3 work url from partial url"""
 
     work_number = parse_text.get_work_number(url)
-    return strings.AO3_BASE_URL + url.split(work_number)[0] + work_number
+    return strings.AO3_BASE_URL + "/works/" + work_number
 
 
 def get_series_urls(soup: BeautifulSoup, get_all: bool) -> list[str]:


### PR DESCRIPTION
Sometimes, a url sent to `get_full_work_url` would contain the absolute URL instead of the relative URL. When this happened, the output of `get_full_work_url` contained the AO3 base URL twice.

Since the work URL always follows the exact same pattern, I set that pattern here.