### PR TITLE
Add shebang for direct execution

### DIFF
--- a/ao3downloader.py
+++ b/ao3downloader.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import ao3downloader.strings as strings
 
 from ao3downloader.actions import ao3download


### PR DESCRIPTION
Hello! This `chmod`s to 755 and adds a python3 shebang so the script can be directly executed without prepending `python3 ...` which is faster and easier in a venv where I'm sure of my version etc.

This has no impact on users who continue using the `python3 ...` invocation.

Thanks for a great project!