### PR TITLE
Extension for download sub-folder, add series-id to file-pattern.

### DIFF
--- a/ao3downloader/ao3.py
+++ b/ao3downloader/ao3.py
@@ -33,9 +33,9 @@ class Ao3:
 
 
     def update(self, link: str, chapters: str) -> None:
-
+        
         log = {}
-
+        
         try:
             self.download_work(link, log, chapters)
         except Exception as e:
@@ -53,7 +53,7 @@ class Ao3:
 
 
     def get_work_links(self, link: str, metadata: bool) -> dict[str, dict]:
-
+        
         links_list = {}
         visited_series = []
 
@@ -112,7 +112,7 @@ class Ao3:
             self.download_work(link, log, None)
         elif parse_text.is_series(link):
             log = {}
-            self.download_series(link, log, visited)
+            self.download_series(link, log, visited)        
         elif strings.AO3_BASE_URL in link:
             while True:
                 thesoup = self.repo.get_soup(link)
@@ -173,7 +173,7 @@ class Ao3:
             currentchapters = parse_soup.get_current_chapters(thesoup)
             if int(currentchapters) <= int(chapters):
                 return False
-
+        
         pattern = self.fileops.get_ini_value(strings.INI_NAME_PATTERN, strings.INI_DEFAULT_NAME_PATTERN)
         pattern_subdir = self.fileops.get_ini_value(strings.INI_DIRNAME_PATTERN, strings.INI_DEFAULT_DIRNAME_PATTERN)
         maximum = self.fileops.get_ini_value_integer(strings.INI_NAME_LENGTH, strings.INI_DEFAULT_NAME_LENGTH)
@@ -205,7 +205,7 @@ class Ao3:
                     counter += 1
                 except Exception as e:
                     self.fileops.write_log({
-                        'message': strings.ERROR_IMAGE, 'link': work_url, 'title': title,
+                        'message': strings.ERROR_IMAGE, 'link': work_url, 'title': title, 
                         'img': img, 'error': str(e), 'stacktrace': traceback.format_exc()})
 
         if self.mark:

--- a/ao3downloader/fileio.py
+++ b/ao3downloader/fileio.py
@@ -81,10 +81,11 @@ class FileOps:
         return logs
 
 
-    def file_exists(self, id: str, titles: dict[str, str], filetypes: list[str], maximum: int) -> bool:
+    def file_exists(self, id: str, titles: dict[str, [str, str]], filetypes: list[str], maximum: int) -> bool:
         if id not in titles: return False
-        filename = parse_text.get_valid_filename(titles[id], maximum)
-        files = list(map(lambda x: os.path.join(self.downloadfolder, filename + '.' + x.lower()), filetypes))
+        filename = parse_text.get_valid_filename(titles[id][0], maximum)
+        dirname = parse_text.get_valid_filename(titles[id][1], maximum)
+        files = list(map(lambda x: os.path.join(self.downloadfolder, dirname, filename + '.' + x.lower()), filetypes))
         for file in files:
             if not os.path.exists(file):
                 return False

--- a/ao3downloader/parse_soup.py
+++ b/ao3downloader/parse_soup.py
@@ -84,8 +84,8 @@ def get_work_urls(soup: BeautifulSoup) -> list[str]:
     """Get all links to ao3 works on a page"""
 
     return list(dict.fromkeys(list(
-        map(lambda w: get_full_work_url(w.get('href')),
-            filter(lambda a : a.get('href') and parse_text.is_work(a.get('href')),
+        map(lambda w: get_full_work_url(w.get('href')), 
+            filter(lambda a : a.get('href') and parse_text.is_work(a.get('href')), 
                    soup.select('.index.group a'))))))
 
 
@@ -102,7 +102,7 @@ def get_series_urls(soup: BeautifulSoup, get_all: bool) -> list[str]:
     bookmarks = None if get_all else soup.find_all('li', class_='bookmark')
 
     return list(dict.fromkeys(list(
-        map(lambda w: get_full_series_url(w.get('href')),
+        map(lambda w: get_full_series_url(w.get('href')), 
             filter(lambda a : a.get('href') and is_series(a, get_all, bookmarks),
                    soup.select('.index.group a'))))))
 
@@ -171,7 +171,7 @@ def get_mark_as_read_link(soup: BeautifulSoup) -> str:
                     .get('href'))
     except:
         return None
-
+    
     if not link:
         return None
 
@@ -276,7 +276,7 @@ def get_current_chapters(soup: BeautifulSoup) -> str:
 
     index = text.find('/')
     if index == -1: return -1
-
+    
     return parse_text.get_current_chapters(text, index)
 
 

--- a/ao3downloader/strings.py
+++ b/ao3downloader/strings.py
@@ -20,9 +20,11 @@ INI_WAIT_TIME = 'ExtraWaitTime'
 INI_PASSWORD_SAVE = 'SavePassword'
 INI_NAME_LENGTH = 'FileNameLength'
 INI_NAME_PATTERN = 'FileNamePattern'
+INI_DIRNAME_PATTERN = 'DirNamePattern'
 
 INI_DEFAULT_NAME_LENGTH = '50'
 INI_DEFAULT_NAME_PATTERN = '{worknum} {title} - {author}'
+INI_DEFAULT_DIRNAME_PATTERN = '{series_title}'
 
 SETTING_USERNAME = 'username'
 SETTING_PASSWORD = 'password'

--- a/settings.ini
+++ b/settings.ini
@@ -1,6 +1,6 @@
 [settings]
 
-# this is the number of seconds to wait between each hit to ao3 IN
+# this is the number of seconds to wait between each hit to ao3 IN 
 # ADDITION to the required wait times when the rate limit is hit.
 # you may wish to set this above zero if you feel that you are
 # hitting the rate limit too often, or if you wish to avoid hitting
@@ -13,10 +13,10 @@ ExtraWaitTime=0
 # not be deleted. to fix this you can delete the 'settings.json' file
 SavePassword=true
 
-# this is the maximum character length of the filename that will be
-# generated for each work. if the filename is longer than this, it
+# this is the maximum character length of the filename that will be 
+# generated for each work. if the filename is longer than this, it 
 # will be truncated. you can set this value to 0 to disable truncation.
-# WARNING: setting this value too large (or to zero) can cause failed
+# WARNING: setting this value too large (or to zero) can cause failed 
 # downloads on Windows due to the maximum file path length restriction
 # set by the Windows operating system.
 FileNameLength=50
@@ -46,7 +46,7 @@ FileNameLength=50
 # applied. also, if you do not put the worknum first, there is a risk of
 # overwriting files if you download multiple works with the same signature.
 # in addition to the above variables, you can use any valid filename
-# characters in the pattern. the list of invalid characters is:
+# characters in the pattern. the list of invalid characters is: 
 #   <>:"/\|?*.
 # note that the period is included in the list of invalid characters.
 # you may use any other unicode characters in the filename pattern.

--- a/settings.ini
+++ b/settings.ini
@@ -1,6 +1,6 @@
 [settings]
 
-# this is the number of seconds to wait between each hit to ao3 IN 
+# this is the number of seconds to wait between each hit to ao3 IN
 # ADDITION to the required wait times when the rate limit is hit.
 # you may wish to set this above zero if you feel that you are
 # hitting the rate limit too often, or if you wish to avoid hitting
@@ -13,10 +13,10 @@ ExtraWaitTime=0
 # not be deleted. to fix this you can delete the 'settings.json' file
 SavePassword=true
 
-# this is the maximum character length of the filename that will be 
-# generated for each work. if the filename is longer than this, it 
+# this is the maximum character length of the filename that will be
+# generated for each work. if the filename is longer than this, it
 # will be truncated. you can set this value to 0 to disable truncation.
-# WARNING: setting this value too large (or to zero) can cause failed 
+# WARNING: setting this value too large (or to zero) can cause failed
 # downloads on Windows due to the maximum file path length restriction
 # set by the Windows operating system.
 FileNameLength=50
@@ -36,6 +36,8 @@ FileNameLength=50
 #   {language} - the language of the work
 #   {published} - the date the work was published
 #   {updated} - the date the work was last updated
+#   {series_number} - comma-separated list of all series id's
+#                     (uniquely identifies the series)
 #   {series_title} - comma-separated list of all series titles for the work
 #   {series_index} - comma-separated list of the position of the work in
 #                    the series it belongs to (same ordering as above)
@@ -44,10 +46,14 @@ FileNameLength=50
 # applied. also, if you do not put the worknum first, there is a risk of
 # overwriting files if you download multiple works with the same signature.
 # in addition to the above variables, you can use any valid filename
-# characters in the pattern. the list of invalid characters is: 
+# characters in the pattern. the list of invalid characters is:
 #   <>:"/\|?*.
 # note that the period is included in the list of invalid characters.
 # you may use any other unicode characters in the filename pattern.
 # invalid characters will not cause an error, but will also not be
 # included in the generated filename.
-FileNamePattern={worknum} {title} - {author}
+FileNamePattern={series_index} {worknum} {title} - {author}
+
+# this is the pattern for the directory created for series in the download
+# folder. all description for FileNamePattern applies here, too.
+DirNamePattern={series_number} {series_title}


### PR DESCRIPTION
Refers to issue #139 

- Makes series number available in FileNamePattern and the new DirNamePattern.
- Several (hopefully small enough) changes to allow sub-folders in the default download folder.
  The changes in `settings.ini` suggest sub-folders by series number/titel, but any of the other file name pattern are good for it, too.
