### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: pytest with coverage


### PR DESCRIPTION
Potential fix for [https://github.com/nianeyna/ao3downloader/security/code-scanning/7](https://github.com/nianeyna/ao3downloader/security/code-scanning/7)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is restricted by default.  
Best fix with no functional change: define workflow-level permissions right after the `on` section (or before `jobs`) with:

- `contents: read`

This is sufficient for `actions/checkout` and running tests, and keeps token scope minimal. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
